### PR TITLE
Point at tag (1.1.0) instead of branch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,8 +25,8 @@ languages:
 
 # Tell the Remote Theme plugin to use the Open SDG platform (Jekyll theme).
 # Recommended: set this to a particular "release" of Open SDG. For example:
-#remote_theme: open-sdg/open-sdg@1.1.0
-remote_theme: open-sdg/open-sdg@master
+remote_theme: open-sdg/open-sdg@1.1.0
+
 
 # Replace this title as needed.
 title: Indicators For The Sustainable Development Goals


### PR DESCRIPTION
@jwestw I'm just pointing at 1.1.0 instead of master as lots of changes will be happening during the 1.2.0 release so want site to be stable